### PR TITLE
Update an artifact ID typo in the mxlib-nbt module

### DIFF
--- a/mxlib.nbt/README.md
+++ b/mxlib.nbt/README.md
@@ -1,6 +1,6 @@
 # mxlib.nbt
 
-`io.github.karlatemp.mxlib:mxlib-net`
+`io.github.karlatemp.mxlib:mxlib-nbt`
 
 Toolkit for reading/writing MineCraft NBT
 


### PR DESCRIPTION
Replace the 'mxlib-net' with 'mxlib-nbt', according to the page on Maven Central ( https://search.maven.org/artifact/io.github.karlatemp.mxlib/mxlib-nbt/3.0-dev-20/jar ), where 'io.github.karlatemp.mxlib:mxlib-nbt' is provided as the artifact ID of Gradle Groovy DSL dependency template.